### PR TITLE
feat(clothes): compute and store color palette on item creation

### DIFF
--- a/src/app/closet/page.tsx
+++ b/src/app/closet/page.tsx
@@ -53,6 +53,7 @@ export default function ClosetPage() {
                 type={it.type}
                 created_at={it.created_at}
                 image_url={it.image_url}
+                palette={it.palette} 
                 priority={idx < 3}
               />
             </li>

--- a/src/components/clothescard.tsx
+++ b/src/components/clothescard.tsx
@@ -1,6 +1,6 @@
+"use client";
+
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
-import ColorThief from "color-thief-browser";
 
 export type ClothingCardProps = {
   id: string;
@@ -10,55 +10,8 @@ export type ClothingCardProps = {
   image_url?: string | null;
   className?: string;
   priority?: boolean;
+  palette?: string[] | null;
 };
-
-
-  function rgbToHsl(r: number, g: number, b: number) {
-    r /= 255; g /= 255; b /= 255;
-    const max = Math.max(r, g, b), min = Math.min(r, g, b);
-    let h = 0, s = 0;
-    const l = (max + min) / 2;
-    const d = max - min;
-
-    if (d !== 0) {
-      s = d / (1 - Math.abs(2 * l - 1));
-      switch (max) {
-        case r: h = ((g - b) / d) % 6; break;
-        case g: h = (b - r) / d + 2; break;
-        case b: h = (r - g) / d + 4; break;
-      }
-      h *= 60;
-      if (h < 0) h += 360;
-    }
-    return { h, s, l }; // s,l in [0..1]
-  }
-
-  function isGrayish([r, g, b]: number[]) {
-    const { s, l } = rgbToHsl(r, g, b);
-    // low saturation OR extreme light/dark → treat as “neutral”
-    return s < 0.15 || l < 0.12 || l > 0.92;
-  }
-
-  function dist(a: number[], b: number[]) {
-    // Euclidean distance in RGB space
-    const dx = a[0] - b[0], dy = a[1] - b[1], dz = a[2] - b[2];
-    return Math.sqrt(dx * dx + dy * dy + dz * dz);
-  }
-
-  function dedupeNear(colors: number[][], threshold = 30) {
-    const out: number[][] = [];
-    for (const c of colors) {
-      if (!out.some(o => dist(o, c) < threshold)) out.push(c);
-    }
-    return out;
-  }
-  // add this helper above useEffect (right under your other helpers)
-  function rgbToHex(r: number, g: number, b: number) {
-    const toHex = (n: number) => n.toString(16).padStart(2, "0");
-    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-  }
-
-
 
 export default function ClothesCard({
   name,
@@ -67,52 +20,9 @@ export default function ClothesCard({
   image_url,
   className,
   priority,
+  palette,
 }: ClothingCardProps) {
-  const [palette, setPalette] = useState<string[]>([]);
-  const hiddenImgRef = useRef<HTMLImageElement | null>(null);
-
-  useEffect(() => {
-    setPalette([]); // reset on URL change
-
-    if (!image_url) return;
-
-    const img = hiddenImgRef.current;
-    if (!img) return;
-
-    const extract = () => {
-      try {
-        const ct = new ColorThief();
-
-        const dominant = ct.getColor(img, 5);
-        const colors = (ct.getPalette(img, 12, 5) || []) as number[][];
-
-        let merged = [dominant, ...colors.filter(c => c.join(",") !== dominant.join(","))];
-        merged = merged.filter(c => !isGrayish(c));
-        merged = dedupeNear(merged, 28);
-
-        const hexes = merged.slice(0, 4).map(([r, g, b]) => rgbToHex(r, g, b));
-        const [dr, dg, db] = dominant as number[];   // narrow the type
-        const fallbackHex = rgbToHex(dr, dg, db);
-        const finalPalette = hexes.length ? hexes : [fallbackHex];
-
-        setPalette(finalPalette);
-      } catch {
-        // quietly ignore extraction errors
-      }
-    };
-
-    if (img.complete && img.naturalWidth > 0) {
-      extract();
-    } else {
-      img.addEventListener("load", extract);
-    }
-
-    // ✅ cleanup: remove listener so it doesn’t run multiple times
-    return () => {
-      img.removeEventListener("load", extract);
-    };
-  }, [image_url]);
-
+  const swatches = (palette ?? []).slice(0, 4);
 
   const dateObj = created_at
     ? (typeof created_at === "string" || typeof created_at === "number"
@@ -125,16 +35,6 @@ export default function ClothesCard({
 
   return (
     <div className={`rounded-lg border bg-card p-4 shadow-sm transition hover:shadow ${className ?? ""}`}>
-      {/* Hidden <img> just for ColorThief */}
-      {image_url && (
-        <img
-          ref={hiddenImgRef}
-          src={image_url}
-          alt=""
-          crossOrigin="anonymous"
-          className="hidden"
-        />
-      )}
 
       <div className="relative mb-3 h-80 w-full overflow-hidden rounded-md border bg-muted/30">
         {image_url ? (
@@ -161,14 +61,16 @@ export default function ClothesCard({
       <p className="mt-2 text-xs text-muted-foreground">Added {dateLabel}</p>
 
       {/* Color swatches */}
-      {palette.length > 0 && (
-        <div className="mt-3 flex gap-2">
-          {palette.map((hex, i) => (
+      {swatches.length > 0 && (
+        <div className="mt-3 flex gap-2" aria-label="Color palette">
+          {swatches.map((hex, i) => (
             <span
               key={i}
               className="h-4 w-4 rounded-full border"
               title={hex}
               style={{ backgroundColor: hex }}
+              aria-label={`Color swatch ${i + 1} ${hex}`}
+              role="img"
             />
           ))}
         </div>

--- a/src/hooks/usePaletteFromImage.ts
+++ b/src/hooks/usePaletteFromImage.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ColorThief from "color-thief-browser";
+import { rgbToHex, isGrayish, dedupeNear, type RGB } from "@/lib/colors";
+
+type Options = {
+  maxColors?: number;   // how many swatches to return (default 4)
+  quality?: number;     // ColorThief quality (default 5; lower = slower/better)
+  paletteSize?: number; // how many colors to sample from the image (default 12)
+};
+
+export function usePaletteFromImage(
+  image_url?: string | null,
+  { maxColors = 4, quality = 5, paletteSize = 12 }: Options = {}
+) {
+  const [palette, setPalette] = useState<string[]>([]);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    setPalette([]); // reset on URL change
+    if (!image_url) return;
+
+    const img = imgRef.current;
+    if (!img) return;
+
+    const extract = () => {
+      try {
+        const ct = new ColorThief();
+
+        // dominant first (so we always have at least one)
+        const dominant = ct.getColor(img, quality) as RGB;
+
+        // broader palette
+        const colors = (ct.getPalette(img, paletteSize, quality) || []) as RGB[];
+
+        // combine, filter, dedupe
+        let merged: RGB[] = [
+          dominant,
+          ...colors.filter(c => c.join(",") !== dominant.join(",")),
+        ];
+        merged = merged.filter(c => !isGrayish(c));
+        merged = dedupeNear(merged, 28);
+
+        // to hex + cap
+        const hexes = merged.slice(0, maxColors).map(([r, g, b]) => rgbToHex(r, g, b));
+
+        // fallback to dominant if everything got filtered
+        const [dr, dg, db] = dominant;
+        setPalette(hexes.length ? hexes : [rgbToHex(dr, dg, db)]);
+      } catch {
+        // ignore extraction errors
+      }
+    };
+
+    if (img.complete && img.naturalWidth > 0) extract();
+    else img.addEventListener("load", extract);
+
+    return () => img.removeEventListener("load", extract);
+  }, [image_url, maxColors, quality, paletteSize]);
+
+  return [palette, imgRef] as const;
+}

--- a/src/hooks/useUserClothes.ts
+++ b/src/hooks/useUserClothes.ts
@@ -14,6 +14,7 @@ export type ClothingItem = {
   type: ItemType;
   created_at: string;
   image_url: string | null;
+  palette?: string[] | null;
 };
 
 function errMsg(e: unknown) {
@@ -47,7 +48,7 @@ export function useUserClothes(filterType?: "top" | "bottom" | "shoes") {
 
       let query = supabase
         .from("clothes")
-        .select("id,user_id,name,type,created_at,image_url")
+        .select("id,user_id,name,type,created_at,image_url,palette")
         .eq("user_id", user.id)
         .order("created_at", { ascending: false });
 

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,52 @@
+// src/lib/colors.ts
+
+export type RGB = [number, number, number];
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export function rgbToHsl(r: number, g: number, b: number) {
+  r /= 255; g /= 255; b /= 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1));
+    switch (max) {
+      case r: h = ((g - b) / d) % 6; break;
+      case g: h = (b - r) / d + 2; break;
+      case b: h = (r - g) / d + 4; break;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return { h, s, l }; // s,l in [0..1]
+}
+
+export function isGrayish([r, g, b]: RGB): boolean {
+  const { s, l } = rgbToHsl(r, g, b);
+  // low saturation OR extreme light/dark → treat as neutral
+  return s < 0.15 || l < 0.12 || l > 0.92;
+}
+
+function dist(a: RGB, b: RGB): number {
+  const dx = a[0] - b[0], dy = a[1] - b[1], dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Remove colors that are "near" another one (keeps the first occurrence).
+ * @param colors list of RGB triplets
+ * @param threshold 0–441 (~sqrt(255^2*3)), typical 24–36
+ */
+export function dedupeNear(colors: RGB[], threshold = 30): RGB[] {
+  const out: RGB[] = [];
+  for (const c of colors) {
+    if (!out.some(o => dist(o, c) < threshold)) out.push(c);
+  }
+  return out;
+}


### PR DESCRIPTION
- Added `palette` column to Supabase `clothes` table
- Updated AddItemPage to extract palette from preview image at upload
- Persist palette with clothing item in DB
- Updated ClothesCard to render swatches from stored palette (removed runtime extraction)

This shifts expensive color analysis to create-time, improving performance and making ClothesCard rendering faster and lighter.