### PR TITLE
feat: implement infinite scroll for closet and clothing type pages

### DIFF
--- a/src/app/closet/add/page.tsx
+++ b/src/app/closet/add/page.tsx
@@ -169,6 +169,7 @@ export default function AddItemPage() {
           <Label htmlFor="photo">Photo (optional)</Label>
           <Input id="photo" type="file" accept="image/*" onChange={onFileChange} />
           {preview && (
+            /* eslint-disable-next-line @next/next/no-img-element */
             <img
               src={preview}
               alt="preview"
@@ -178,6 +179,7 @@ export default function AddItemPage() {
         </div>
 
         {preview && (
+          /* eslint-disable-next-line @next/next/no-img-element */
           <img
             ref={imgRef}
             src={preview}

--- a/src/app/closet/layout.tsx
+++ b/src/app/closet/layout.tsx
@@ -5,7 +5,7 @@ export default function ClosetLayout({ children }: { children: ReactNode }) {
   return (
     <div className="md:flex">
       <SideNav />
-      <main className="flex-1 min-h-[100dvh] bg-background">
+      <main className="flex-1 min-h-[100dvh] bg-background border">
         {children}
       </main>
     </div>

--- a/src/app/closet/page.tsx
+++ b/src/app/closet/page.tsx
@@ -3,13 +3,38 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import ClothesCard from "@/components/clothescard";
-import { useUserClothes } from "@/hooks/useUserClothes";
+import { usePagedClothes } from "@/hooks/usePagedClothes";
 
 export default function ClosetPage() {
-  const { loading, error, email, items } = useUserClothes();
+  const {
+    email,
+    items,
+    error,
+    isLoadingInitial,        // initial page loading
+    isFetchingNextPage,      // loading more pages
+    hasMore,                 // whether more pages exist
+    setSentinelRef,          // assign to a div at the bottom
+  } = usePagedClothes({ pageSize: 6 });
 
-  if (loading) {
-    return <p className="p-6 text-center">Loading your closet…</p>;
+  // 2) Initial loading state
+  if (isLoadingInitial) {
+    return (
+      <main className="p-6 space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <h1 className="text-3xl font-bold">Your Closet</h1>
+        </div>
+
+        {/* simple skeletons */}
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="rounded-lg border p-4">
+              <div className="mb-3 h-80 w-full rounded-md bg-muted/30 animate-pulse" />
+              <div className="h-4 w-2/3 bg-muted/30 rounded animate-pulse" />
+            </li>
+          ))}
+        </ul>
+      </main>
+    );
   }
 
   return (
@@ -44,6 +69,7 @@ export default function ClosetPage() {
           </Button>
         </div>
       ) : (
+        <>
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((it, idx) => (
             <li key={it.id}>
@@ -53,13 +79,23 @@ export default function ClosetPage() {
                 type={it.type}
                 created_at={it.created_at}
                 image_url={it.image_url}
-                palette={it.palette} 
+                palette={it.palette}
                 priority={idx < 3}
               />
             </li>
           ))}
         </ul>
-      )}
-    </main>
+        
+         {/* loader / sentinel */}
+         <div ref={setSentinelRef} className="py-6 flex justify-center">
+         {isFetchingNextPage ? (
+           <div className="text-lg text-muted-foreground">Loading more…</div>
+         ) : !hasMore ? (
+           <div className="text-xs text-muted-foreground">No more items.</div>
+         ) : null}
+       </div>
+     </>
+   )}
+ </main>
   );
 }

--- a/src/components/ClothingTypePage.tsx
+++ b/src/components/ClothingTypePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useUserClothes } from "@/hooks/useUserClothes";
+import { usePagedClothes } from "@/hooks/usePagedClothes";
 import ClothesCard from "@/components/clothescard";
 
 type ItemType = "top" | "bottom" | "shoes";
@@ -11,9 +11,31 @@ type ClothingTypePageProps = {
 };
 
 export default function ClothingTypePage({ title, filterType }: ClothingTypePageProps) {
-  const { loading, error, items } = useUserClothes(filterType);
+  const {
+    items,
+    error,
+    isLoadingInitial,
+    isFetchingNextPage,
+    hasMore,
+    setSentinelRef,
+  } = usePagedClothes({ pageSize: 6, filterType });
 
-  if (loading) return <main className="p-6">Loading {title.toLowerCase()}…</main>;
+
+  if (isLoadingInitial) {
+    return (
+      <main className="p-6 space-y-4">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="rounded-lg border p-4">
+              <div className="mb-3 h-80 w-full rounded-md bg-muted/30 animate-pulse" />
+              <div className="h-4 w-2/3 bg-muted/30 rounded animate-pulse" />
+            </li>
+          ))}
+        </ul>
+      </main>
+    );
+  }
 
   if (error) {
     return (
@@ -29,6 +51,7 @@ export default function ClothingTypePage({ title, filterType }: ClothingTypePage
       {items.length === 0 ? (
         <p className="text-sm text-muted-foreground">No {filterType}s yet.</p>
       ) : (
+        <>
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((it, idx) => (
             <li key={it.id}>
@@ -38,11 +61,21 @@ export default function ClothingTypePage({ title, filterType }: ClothingTypePage
                 type={it.type}
                 created_at={it.created_at}
                 image_url={it.image_url}
+                palette={it.palette}             
                 priority={idx < 3}
               />
             </li>
           ))}
         </ul>
+        {/* infinite scroll sentinel / loader */}
+        <div ref={setSentinelRef} className="py-6 flex justify-center">
+            {isFetchingNextPage ? (
+              <div className="text-sm text-muted-foreground">Loading more…</div>
+            ) : !hasMore ? (
+              <div className="text-xs text-muted-foreground">No more items.</div>
+            ) : null}
+          </div>
+        </>
       )}
     </main>
   );

--- a/src/hooks/usePagedClothes.ts
+++ b/src/hooks/usePagedClothes.ts
@@ -63,8 +63,8 @@ export function usePagedClothes({ filterType, pageSize = 6 }: Options = {}) {
         setItems(prev => (append ? [...prev, ...rows] : rows));
         setPage(pageIndex);
         setError(null);
-      } catch (e: any) {
-        setError(e?.message ?? String(e));
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : String(e));
       } finally {
         setIsLoadingInitial(false);
         setIsFetchingNextPage(false);

--- a/src/hooks/usePagedClothes.ts
+++ b/src/hooks/usePagedClothes.ts
@@ -1,0 +1,135 @@
+// src/hooks/usePagedClothes.ts
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export type ItemType = "top" | "bottom" | "shoes" | string;
+export type ClothingItem = {
+  id: string;
+  user_id: string;
+  name: string;
+  type: ItemType;
+  created_at: string;
+  image_url: string | null;
+  palette?: string[] | null;
+};
+
+type Options = {
+  filterType?: "top" | "bottom" | "shoes";
+  pageSize?: number;
+};
+
+export function usePagedClothes({ filterType, pageSize = 6 }: Options = {}) {
+  const router = useRouter();
+
+  const [email, setEmail] = useState<string | null>(null);
+  const [items, setItems] = useState<ClothingItem[]>([]);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  const fetchPage = useCallback(
+    async (pageIndex: number, append: boolean) => {
+      try {
+        const { data: sessionRes } = await supabase.auth.getSession();
+        const session = sessionRes?.session;
+        if (!session) {
+          router.replace("/");
+          return;
+        }
+        setEmail(session.user.email ?? null);
+
+        const from = pageIndex * pageSize;
+        const to = from + pageSize - 1;
+
+        let query = supabase
+          .from("clothes")
+          .select("id,user_id,name,type,created_at,image_url,palette")
+          .eq("user_id", session.user.id)
+          .order("created_at", { ascending: false })
+          .range(from, to);
+
+        if (filterType) query = query.eq("type", filterType);
+
+        const { data, error } = await query;
+        if (error) throw error;
+
+        const rows = data ?? [];
+        setHasMore(rows.length === pageSize);
+        setItems(prev => (append ? [...prev, ...rows] : rows));
+        setPage(pageIndex);
+        setError(null);
+      } catch (e: any) {
+        setError(e?.message ?? String(e));
+      } finally {
+        setIsLoadingInitial(false);
+        setIsFetchingNextPage(false);
+      }
+    },
+    [router, filterType, pageSize]
+  );
+
+  const refresh = useCallback(async () => {
+    setIsLoadingInitial(true);
+    setHasMore(true);
+    await fetchPage(0, false);
+  }, [fetchPage]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const loadMore = useCallback(async () => {
+    if (isFetchingNextPage || !hasMore) return;
+    setIsFetchingNextPage(true);
+    await fetchPage(page + 1, true);
+  }, [fetchPage, page, isFetchingNextPage, hasMore]);
+
+  // IntersectionObserver glue
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const setSentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      // cleanup previous observer
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      if (!node) return;
+
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          const first = entries[0];
+          if (first.isIntersecting && !isLoadingInitial) loadMore();
+        },
+        { root: null, rootMargin: "300px", threshold: 0 }
+      );
+
+      observerRef.current.observe(node);
+    },
+    [loadMore, isLoadingInitial]);
+
+    // cleanup on unmount
+    useEffect(() => {
+      return () => {
+        if (observerRef.current) observerRef.current.disconnect();
+      };
+    }, 
+[]);
+
+
+  return {
+    email,
+    items,
+    error,
+    isLoadingInitial,
+    isFetchingNextPage,
+    hasMore,
+    loadMore,         // still exposed if you want a manual “Load more” button
+    setSentinelRef,   // assign this to a <div ref={...} /> at the bottom
+    pageSize
+  };
+}


### PR DESCRIPTION
- Added new `usePagedClothes` hook with paginated Supabase queries
- Integrated IntersectionObserver to auto-load more items on scroll
- Updated ClosetPage and ClothingTypePage (tops, bottoms, shoes) to use infinite scroll instead of loading all items at once
- Added skeleton placeholders for initial load and a sentinel loader (“Loading more…” / “No more items”) for better UX
- Improves performance and scalability for large closets