### PR TITLE
feat: add AI auto-tagging for clothing items

### DIFF
--- a/src/app/ai-test/page.tsx
+++ b/src/app/ai-test/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+export default function TestPage() {
+    const [result, setResult] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    async function getAiTest() {
+        try {
+            const res = await fetch("/api/ai", {
+                method: "POST",
+                body: JSON.stringify({ input: "Write a haiku about Wardro closets" }),
+                headers: { "Content-Type": "application/json" },
+            });
+
+            if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+            const data = await res.json();
+            console.log("AI Response:", data);
+            setResult(JSON.stringify(data, null, 2));
+        } catch (err) {
+            console.error(err);
+            setError(String(err));
+        }
+    }
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-bold mb-4">AI Test Page</h1>
+            <button
+                onClick={getAiTest}
+                className="px-4 py-2 bg-black text-white rounded"
+            >
+                Test AI
+            </button>
+
+            {result && (
+                <pre className="mt-4 p-2 bg-gray-100 rounded">{result}</pre>
+            )}
+            {error && <p className="text-red-500 mt-4">{error}</p>}
+        </main>
+    );
+}

--- a/src/app/api/ai-tags/route.ts
+++ b/src/app/api/ai-tags/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    try {
+        const { imageUrl } = await req.json();
+
+        if (!imageUrl) {
+            return NextResponse.json({ error: "Missing imageUrl" }, { status: 400 });
+        }
+
+        const res = await fetch("https://api.openai.com/v1/responses", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${process.env.OPENAI_API_KEY!}`,
+            },
+            body: JSON.stringify({
+                model: "gpt-4o-mini",
+                input: [
+                    {
+                        role: "user",
+                        content: [
+                            {
+                                type: "input_text",
+                                text:
+                                    `Return 3–6 concise style tags (lowercase, comma-separated). 
+                   Example: "casual,streetwear,red,denim,minimal".`,
+                            },
+                            { type: "input_image", image_url: imageUrl },
+                        ],
+                    },
+                ],
+            }),
+        });
+
+        const data = await res.json();
+
+        // Try to parse text output into tags
+        const text = data?.output?.[0]?.content?.[0]?.text || "";
+        const tags = text
+            .split(/[,|\n]/)
+            .map((t: string) => t.trim().toLowerCase())
+            .filter(Boolean);
+
+        return NextResponse.json({ tags: Array.from(new Set(tags)).slice(0, 6) });
+    } catch (err: any) {
+        return NextResponse.json({ error: String(err) }, { status: 500 });
+    }
+}

--- a/src/app/api/ai-tags/route.ts
+++ b/src/app/api/ai-tags/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
             .filter(Boolean);
 
         return NextResponse.json({ tags: Array.from(new Set(tags)).slice(0, 6) });
-    } catch (err: any) {
+    } catch (err: unknown) {
         return NextResponse.json({ error: String(err) }, { status: 500 });
     }
 }

--- a/src/app/api/auto-tag/route.ts
+++ b/src/app/api/auto-tag/route.ts
@@ -1,0 +1,74 @@
+// src/app/api/auto-tag/route.ts
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    try {
+        const { imageUrl, name, type, palette } = await req.json();
+
+        if (!process.env.OPENAI_API_KEY) {
+            return NextResponse.json({ error: "Missing OPENAI_API_KEY" }, { status: 500 });
+        }
+        if (!imageUrl) {
+            return NextResponse.json({ tags: [] });
+        }
+
+        // Ask for 2–4 short tags; keep lowercase; no spaces inside tags.
+        const prompt = [
+            "You are labeling wardrobe items. Return 2-4 concise lowercase tags (no spaces; use hyphens if needed).",
+            "Prefer: color, garment features, style vibe, seasonality.",
+            "Avoid duplicates and brand names. JSON only: {\"tags\": [\"...\"]}",
+            `Name: ${name ?? ""}`,
+            `Type: ${type ?? ""}`,
+            `Palette (hex): ${Array.isArray(palette) ? palette.join(", ") : ""}`,
+        ].join("\n");
+
+        const res = await fetch("https://api.openai.com/v1/responses", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            },
+            body: JSON.stringify({
+                model: "gpt-4o-mini",
+                input: [
+                    { role: "user", content: [
+                            { type: "input_text", text: prompt },
+                            { type: "input_image", image_url: imageUrl }
+                        ] }
+                ],
+                temperature: 0.2,
+            }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) {
+            // graceful fallback
+            return NextResponse.json({ tags: [], error: data?.error ?? "ai_error" }, { status: 200 });
+        }
+
+        // The Responses API returns structured output in data.output[0].content[0].text
+        const text = data?.output?.[0]?.content?.[0]?.text ?? "";
+        let tags: string[] = [];
+        try {
+            const parsed = JSON.parse(text) as { tags?: unknown };
+            if (Array.isArray(parsed.tags)) {
+                tags = (parsed.tags as unknown[]).map(String);
+            }
+        } catch {
+            // very defensive: try to scrape bracket content
+            const m = text.match(/\[([\s\S]*?)\]/);
+            if (m) {
+                tags = m[1]
+                    .split(",")
+                    .map((s: string) => s.replace(/["'\s]/g, "").toLowerCase())
+                    .filter(Boolean);
+            }
+        }
+
+        // normalize & cap to 4
+        tags = [...new Set(tags.map(t => t.trim().toLowerCase()))].slice(0, 4);
+        return NextResponse.json({ tags });
+    } catch (err) {
+        return NextResponse.json({ tags: [], error: String(err) }, { status: 200 });
+    }
+}

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, KeyboardEvent } from "react";
+import { X } from "lucide-react";
+
+type Props = {
+    value: string[];
+    onChange: (next: string[]) => void;
+    placeholder?: string;
+    maxTags?: number;
+};
+
+export default function TagInput({
+                                     value,
+                                     onChange,
+                                     placeholder,
+                                     maxTags = Infinity,
+                                 }: Props) {
+    const [draft, setDraft] = useState("");
+
+    const atMax = value.length >= maxTags;
+
+    function addTag(raw: string) {
+        const t = raw.trim().toLowerCase();
+        if (!t) return;
+        if (value.includes(t)) return;
+        if (atMax) return;
+        onChange([...value, t]);
+    }
+
+    function removeTag(tag: string) {
+        onChange(value.filter((t) => t !== tag));
+    }
+
+    function onKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+        if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+            e.preventDefault();
+            addTag(draft);
+            setDraft("");
+        }
+        if (e.key === " " && draft.trim().length > 0) {
+            e.preventDefault();
+            addTag(draft);
+            setDraft("");
+        }
+    }
+
+    return (
+        <div className="w-full rounded-md border bg-background p-2">
+            <div className="flex flex-wrap gap-2">
+                {value.map((tag) => (
+                    <span
+                        key={tag}
+                        className="inline-flex items-center gap-1 rounded-full border px-2 py-1 text-sm"
+                    >
+            {tag}
+                        <button
+                            type="button"
+                            onClick={() => removeTag(tag)}
+                            className="rounded-full p-0.5 hover:bg-muted"
+                            aria-label={`Remove ${tag}`}
+                        >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </span>
+                ))}
+
+                <input
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onKeyDown={onKeyDown}
+                    placeholder={
+                        atMax ? "Max tags reached" : placeholder ?? "Type and press Enter"
+                    }
+                    disabled={atMax}
+                    className="min-w-[8rem] flex-1 bg-transparent outline-none text-sm px-1 py-1 disabled:opacity-50"
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/usePagedClothes.ts
+++ b/src/hooks/usePagedClothes.ts
@@ -14,6 +14,7 @@ export type ClothingItem = {
   created_at: string;
   image_url: string | null;
   palette?: string[] | null;
+  tags?: string[] | null;
 };
 
 function dedupeById<T extends { id: string }>(arr: T[]) {
@@ -53,7 +54,7 @@ export function usePagedClothes({ filterType, pageSize = 6 }: Options = {}) {
 
         let query = supabase
           .from("clothes")
-          .select("id,user_id,name,type,created_at,image_url,palette")
+          .select("id,user_id,name,type,created_at,image_url,palette, tags")
           .eq("user_id", session.user.id)
           .order("created_at", { ascending: false })
             .order("id", { ascending: false })


### PR DESCRIPTION
- Created `/api/auto-tag` endpoint using OpenAI Responses API (gpt-4o-mini)
- Implemented server-side prompt to suggest 2–4 concise lowercase tags (color, style, seasonality)
- Updated AddItem and EditItem flows: • Upload image → fetch AI tags → merge with user tags → save to Supabase • Ensure no duplicates, normalize to lowercase, cap at 4
- Added TagInput component for chip-style tag editing
- Require photo upload before submitting new items
- Fixed TS issues in auto-tag route: • Replaced `/s` regex flag with `[\s\S]` • Explicitly typed parsed tags to avoid implicit `any`
- Verified tags display correctly on Edit page